### PR TITLE
Use embedded logo image in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,11 @@
     <header id="inicio">
       <div class="navbar">
         <div class="brand">
-          <span class="brand-logo" aria-hidden="true">🐂</span>
+          <img
+            class="brand-logo"
+            src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMjAgMTIwIiB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCI+CiAgPGRlZnM+CiAgICA8bGluZWFyR3JhZGllbnQgaWQ9ImdyYWQiIHgxPSIwJSIgeTE9IjAlIiB4Mj0iMTAwJSIgeTI9IjEwMCUiPgogICAgICA8c3RvcCBvZmZzZXQ9IjAlIiBzdG9wLWNvbG9yPSIjZmY3YTU5IiAvPgogICAgICA8c3RvcCBvZmZzZXQ9IjEwMCUiIHN0b3AtY29sb3I9IiNmZmIzNDciIC8+CiAgICA8L2xpbmVhckdyYWRpZW50PgogIDwvZGVmcz4KICA8cmVjdCB3aWR0aD0iMTIwIiBoZWlnaHQ9IjEyMCIgcng9IjI0IiBmaWxsPSJ1cmwoI2dyYWQpIiAvPgogIDxwYXRoIGQ9Ik0zMiA4MiBMNDQgMzggSDU4IEw1MCA3MCBINzAgTDYyIDM4IEg3NiBMODggODIgSDc0IEw2OCA2MCBINTIgTDQ2IDgyIFoiIGZpbGw9IiNmZmYiIC8+Cjwvc3ZnPg=="
+            alt="Logo de Tesaco el Toro"
+          />
           <span>Tesaco el Toro</span>
         </div>
         <nav aria-label="Navegación principal">

--- a/styles.css
+++ b/styles.css
@@ -57,11 +57,11 @@ header {
 .brand-logo {
   width: 48px;
   height: 48px;
-  border-radius: 50%;
-  background: linear-gradient(135deg, var(--rojo-torero), var(--dorado-capote));
-  display: grid;
-  place-items: center;
-  font-size: 1.2rem;
+  border-radius: 16px;
+  display: block;
+  object-fit: cover;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.25);
+  flex-shrink: 0;
 }
 
 nav ul {


### PR DESCRIPTION
## Summary
- replace the placeholder emoji logo in the header with the provided base64-encoded logo asset
- adjust navbar logo styling to accommodate the new image presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81acd2624832f85504bf51a7650b2