### PR TITLE
Add Diwo chatbot widget with rotating messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,6 +251,14 @@
       <p>Hecho con arte sevillano y humor picante para Rome.</p>
     </footer>
 
+    <div class="diwo-chatbot" role="complementary" aria-live="polite" aria-label="Chatbot ficticio Diwo">
+      <div class="diwo-chatbot__header">
+        <span class="diwo-chatbot__avatar" aria-hidden="true">🤖</span>
+        <span class="diwo-chatbot__title">Diwo</span>
+      </div>
+      <div class="diwo-chatbot__message" id="diwo-message"></div>
+    </div>
+
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -56,3 +56,26 @@ const yearSpan = document.getElementById("current-year");
 if (yearSpan) {
   yearSpan.textContent = new Date().getFullYear();
 }
+
+const diwoMessages = [
+  "yamilet no te vayas",
+  "caida de roma",
+  "dameApi",
+  "15 instalaciones de Emooc",
+  "buen curro",
+  "nowena",
+];
+
+const diwoMessageElement = document.getElementById("diwo-message");
+
+if (diwoMessageElement) {
+  let diwoIndex = 0;
+
+  const rotateMessage = () => {
+    diwoMessageElement.textContent = diwoMessages[diwoIndex];
+    diwoIndex = (diwoIndex + 1) % diwoMessages.length;
+  };
+
+  rotateMessage();
+  setInterval(rotateMessage, 5000);
+}

--- a/styles.css
+++ b/styles.css
@@ -382,6 +382,51 @@ footer a {
   text-decoration: none;
 }
 
+.diwo-chatbot {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  width: min(280px, 90vw);
+  border-radius: 18px;
+  background: white;
+  box-shadow: 0 18px 35px rgba(26, 26, 26, 0.25);
+  border: 2px solid rgba(179, 0, 27, 0.15);
+  overflow: hidden;
+  font-family: var(--fuente-principal);
+  z-index: 1000;
+}
+
+.diwo-chatbot__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--rojo-torero);
+  color: white;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+}
+
+.diwo-chatbot__avatar {
+  font-size: 1.25rem;
+}
+
+.diwo-chatbot__message {
+  padding: 1rem 1.25rem;
+  font-size: 0.95rem;
+  min-height: 3rem;
+  display: flex;
+  align-items: center;
+  color: var(--negro-tela);
+}
+
+@media (max-width: 600px) {
+  .diwo-chatbot {
+    bottom: 1rem;
+    right: 1rem;
+  }
+}
+
 @media (max-width: 720px) {
   nav ul {
     display: none;


### PR DESCRIPTION
## Summary
- add a fixed Diwo chatbot panel to the layout footer area
- style the chatbot to match the existing branding
- cycle through the required Diwo catchphrases every 5 seconds automatically

## Testing
- No automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d81d1465a4832fa4248ddc18a3e143