### PR TITLE
Add Diwo chatbot overlay with automated rotating messages

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,6 +224,21 @@
       <p>Hecho con arte sevillano y humor picante para Rome.</p>
     </footer>
 
+    <section
+      id="diwo-chatbot"
+      class="diwo-chatbot"
+      aria-live="polite"
+      aria-label="Chatbot ficticio Diwo compartiendo mensajes"
+    >
+      <header class="diwo-chatbot__header">
+        <span class="diwo-chatbot__avatar" aria-hidden="true">💬</span>
+        <span class="diwo-chatbot__title">Diwo</span>
+      </header>
+      <div class="diwo-chatbot__body">
+        <p id="diwo-message" class="diwo-chatbot__message"></p>
+      </div>
+    </section>
+
     <script src="script.js"></script>
   </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,29 @@ if (yearSpan) {
   yearSpan.textContent = new Date().getFullYear();
 }
 
+const diwoMessage = document.getElementById("diwo-message");
+
+if (diwoMessage) {
+  const diwoMessages = [
+    "yamilet no te vayas",
+    "caida de roma",
+    "dameApi",
+    "15 instalaciones de Emooc",
+    "buen curro",
+    "nowena",
+  ];
+
+  let currentMessageIndex = 0;
+
+  const renderDiwoMessage = () => {
+    diwoMessage.textContent = diwoMessages[currentMessageIndex];
+    currentMessageIndex = (currentMessageIndex + 1) % diwoMessages.length;
+  };
+
+  renderDiwoMessage();
+  setInterval(renderDiwoMessage, 5000);
+}
+
 if (quizApp) {
   const questions = [
     {

--- a/styles.css
+++ b/styles.css
@@ -446,6 +446,73 @@ footer a {
   text-decoration: none;
 }
 
+.diwo-chatbot {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  width: min(320px, 90vw);
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 18px;
+  box-shadow: 0 18px 45px rgba(26, 26, 26, 0.2);
+  border: 2px solid rgba(179, 0, 27, 0.15);
+  overflow: hidden;
+  z-index: 1000;
+}
+
+.diwo-chatbot__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: linear-gradient(135deg, rgba(179, 0, 27, 0.9), rgba(245, 197, 66, 0.85));
+  color: white;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.diwo-chatbot__avatar {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.18);
+  font-size: 1.1rem;
+}
+
+.diwo-chatbot__body {
+  padding: 1rem 1.2rem;
+  background: rgba(255, 255, 255, 0.92);
+}
+
+.diwo-chatbot__message {
+  margin: 0;
+  font-weight: 600;
+  color: var(--negro-tela);
+  animation: diwo-fade 0.6s ease;
+}
+
+@keyframes diwo-fade {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (max-width: 600px) {
+  .diwo-chatbot {
+    right: 1rem;
+    bottom: 1rem;
+    width: calc(100% - 2rem);
+  }
+}
+
 @media (max-width: 720px) {
   nav ul {
     display: none;


### PR DESCRIPTION
## Summary
- add an on-page widget for el chatbot ficticio Diwo mostrando mensajes en el pie
de la página
- aplicar estilos fijos y responsivos para que el chatbot se muestre en la esquina
inferior derecha con animación suave
- automatizar la rotación de los mensajes de Diwo cada 5 segundos desde
JavaScript

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d81f6f6a6c832f982cd144b23ce06c