### PR TITLE
Add interactive response loop to Diwo chatbot

### DIFF
--- a/index.html
+++ b/index.html
@@ -227,16 +227,36 @@
     <section
       id="diwo-chatbot"
       class="diwo-chatbot"
-      aria-live="polite"
       aria-label="Chatbot ficticio Diwo compartiendo mensajes"
     >
       <header class="diwo-chatbot__header">
         <span class="diwo-chatbot__avatar" aria-hidden="true">💬</span>
         <span class="diwo-chatbot__title">Diwo</span>
       </header>
-      <div class="diwo-chatbot__body">
-        <p id="diwo-message" class="diwo-chatbot__message"></p>
+      <div
+        class="diwo-chatbot__body"
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions"
+      >
+        <ul id="diwo-messages" class="diwo-chatbot__messages"></ul>
       </div>
+      <form id="diwo-chat-form" class="diwo-chatbot__form">
+        <label class="sr-only" for="diwo-chat-input"
+          >Escribe un mensaje para Diwo</label
+        >
+        <input
+          id="diwo-chat-input"
+          class="diwo-chatbot__input"
+          type="text"
+          name="diwo-message"
+          placeholder="Escribe aquí..."
+          autocomplete="off"
+          maxlength="240"
+          aria-label="Mensaje para Diwo"
+        />
+        <button type="submit" class="diwo-chatbot__send">Enviar</button>
+      </form>
     </section>
 
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -5,9 +5,33 @@ if (yearSpan) {
   yearSpan.textContent = new Date().getFullYear();
 }
 
-const diwoMessage = document.getElementById("diwo-message");
+const diwoMessagesList = document.getElementById("diwo-messages");
+const diwoChatBody = document.querySelector("#diwo-chatbot .diwo-chatbot__body");
+const diwoChatForm = document.getElementById("diwo-chat-form");
+const diwoChatInput = document.getElementById("diwo-chat-input");
 
-if (diwoMessage) {
+const appendDiwoMessage = (text, author = "bot") => {
+  if (!diwoMessagesList) {
+    return;
+  }
+
+  const messageItem = document.createElement("li");
+  messageItem.classList.add("diwo-chatbot__message");
+  messageItem.classList.add(
+    author === "user" ? "diwo-chatbot__message--user" : "diwo-chatbot__message--bot"
+  );
+
+  const messageText = document.createElement("span");
+  messageText.textContent = text;
+
+  messageItem.appendChild(messageText);
+  diwoMessagesList.appendChild(messageItem);
+
+  const scrollTarget = diwoChatBody ?? diwoMessagesList;
+  scrollTarget.scrollTop = scrollTarget.scrollHeight;
+};
+
+if (diwoMessagesList) {
   const diwoMessages = [
     "yamilet no te vayas",
     "caida de roma",
@@ -20,12 +44,31 @@ if (diwoMessage) {
   let currentMessageIndex = 0;
 
   const renderDiwoMessage = () => {
-    diwoMessage.textContent = diwoMessages[currentMessageIndex];
+    appendDiwoMessage(diwoMessages[currentMessageIndex]);
     currentMessageIndex = (currentMessageIndex + 1) % diwoMessages.length;
   };
 
   renderDiwoMessage();
   setInterval(renderDiwoMessage, 5000);
+}
+
+if (diwoChatForm && diwoChatInput) {
+  diwoChatForm.addEventListener("submit", (event) => {
+    event.preventDefault();
+
+    const userMessage = diwoChatInput.value.trim();
+    if (!userMessage) {
+      return;
+    }
+
+    appendDiwoMessage(userMessage, "user");
+    diwoChatInput.value = "";
+    diwoChatInput.focus();
+
+    setTimeout(() => {
+      appendDiwoMessage("no se puede orinar en el AVE");
+    }, 500);
+  });
 }
 
 if (quizApp) {

--- a/styles.css
+++ b/styles.css
@@ -484,6 +484,19 @@ footer a {
 .diwo-chatbot__body {
   padding: 1rem 1.2rem;
   background: rgba(255, 255, 255, 0.92);
+  max-height: 260px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.diwo-chatbot__messages {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
 }
 
 .diwo-chatbot__message {
@@ -491,6 +504,87 @@ footer a {
   font-weight: 600;
   color: var(--negro-tela);
   animation: diwo-fade 0.6s ease;
+  padding: 0.75rem 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(179, 0, 27, 0.12);
+  max-width: 85%;
+  box-shadow: 0 8px 18px rgba(26, 26, 26, 0.08);
+}
+
+.diwo-chatbot__message--bot {
+  align-self: flex-start;
+  background: linear-gradient(
+    135deg,
+    rgba(179, 0, 27, 0.1),
+    rgba(245, 197, 66, 0.25)
+  );
+  border-color: rgba(179, 0, 27, 0.3);
+}
+
+.diwo-chatbot__message--user {
+  align-self: flex-end;
+  background: rgba(179, 0, 27, 0.85);
+  color: white;
+  border-color: rgba(179, 0, 27, 0.85);
+}
+
+.diwo-chatbot__form {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-top: 1px solid rgba(179, 0, 27, 0.15);
+}
+
+.diwo-chatbot__input {
+  flex: 1;
+  border: 1px solid rgba(179, 0, 27, 0.2);
+  border-radius: 999px;
+  padding: 0.5rem 1rem;
+  font-family: inherit;
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.diwo-chatbot__input:focus {
+  border-color: rgba(179, 0, 27, 0.55);
+  box-shadow: 0 0 0 3px rgba(179, 0, 27, 0.15);
+}
+
+.diwo-chatbot__send {
+  border: none;
+  background: linear-gradient(135deg, rgba(179, 0, 27, 0.95), rgba(245, 197, 66, 0.9));
+  color: white;
+  font-weight: 700;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.diwo-chatbot__send:hover,
+.diwo-chatbot__send:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 18px rgba(179, 0, 27, 0.25);
+}
+
+.diwo-chatbot__send:active {
+  transform: translateY(0);
+  box-shadow: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 @keyframes diwo-fade {


### PR DESCRIPTION
## Summary
- add a message log and input form so visitors can escribirle a Diwo
- style the chatbot interface with bubbles and controls que distinguen usuario y bot
- mantener el carrusel de mensajes cada 5 segundos y responder siempre "no se puede orinar en el AVE"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d820ace460832f8e1f76a15056ed04