### PR TITLE
Improve quiz nav emphasis and Diwo mobile layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,12 @@
             <li><a href="#galeria">Galería</a></li>
             <li><a href="#nosotros">Nosotros</a></li>
             <li><a href="#contacto">Contacto</a></li>
-            <li><a href="#quiz">Quiz Taurino</a></li>
+            <li>
+              <a class="nav-link nav-link--quiz" href="#quiz">
+                <span class="nav-link--quiz__icon" aria-hidden="true">🎯</span>
+                <span class="nav-link--quiz__label">Quiz Taurino</span>
+              </a>
+            </li>
           </ul>
         </nav>
       </div>

--- a/styles.css
+++ b/styles.css
@@ -106,6 +106,39 @@ header {
   transform: translateY(-2px);
 }
 
+.primary-nav .nav-link--quiz {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: linear-gradient(135deg, rgba(245, 197, 66, 0.9), rgba(179, 0, 27, 0.9));
+  color: var(--negro-tela);
+  font-weight: 700;
+  padding: 0.5rem 1rem;
+  box-shadow: 0 12px 25px rgba(179, 0, 27, 0.25);
+}
+
+.primary-nav .nav-link--quiz:hover,
+.primary-nav .nav-link--quiz:focus {
+  color: var(--negro-tela);
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 18px 35px rgba(179, 0, 27, 0.3);
+}
+
+.primary-nav .nav-link--quiz:focus-visible {
+  outline: 3px solid rgba(245, 197, 66, 0.6);
+  outline-offset: 3px;
+}
+
+.nav-link--quiz__icon {
+  font-size: 1.1rem;
+}
+
+.nav-link--quiz__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 .nav-toggle {
   display: none;
   align-items: center;
@@ -568,7 +601,7 @@ footer a {
 .diwo-chatbot__body {
   padding: 1rem 1.2rem;
   background: rgba(255, 255, 255, 0.92);
-  max-height: 260px;
+  max-height: clamp(200px, 50vh, 320px);
   overflow-y: auto;
   display: flex;
   flex-direction: column;
@@ -755,6 +788,12 @@ footer a {
     padding: 0.9rem 0.25rem;
   }
 
+  .primary-nav .nav-link--quiz {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+  }
+
   .hero {
     text-align: left;
     padding: 4rem 1.25rem 2.5rem;
@@ -803,12 +842,41 @@ footer a {
   }
 
   .diwo-chatbot {
-    right: 1rem;
-    bottom: 1rem;
-    width: calc(100% - 2rem);
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    width: auto;
+    border-radius: 22px;
   }
 
   footer {
     padding: 2rem 1.25rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .diwo-chatbot__form {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .diwo-chatbot__send {
+    width: 100%;
+  }
+}
+
+@media (max-width: 480px) {
+  .diwo-chatbot {
+    left: 0.5rem;
+    right: 0.5rem;
+    bottom: 0.5rem;
+    border-radius: 20px;
+  }
+
+  .diwo-chatbot__header {
+    justify-content: center;
+    text-align: center;
+    gap: 0.75rem;
   }
 }


### PR DESCRIPTION
## Summary
- highlight the Quiz Taurino link in the header with an icon and gradient styling to make it a clearer call to action
- adjust the Diwo chatbot layout to better fit small screens and allow its feed height to adapt to the viewport
- stack the chatbot input controls on very narrow devices and refine mobile spacing around the floating widget

## Testing
- No automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d9495aa8e8832fa4efd639aa18a672