### PR TITLE
Add mobile toggle for team section

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,7 +151,18 @@
             Somos un equipo de especialistas en todo lo que tenga cuernos, pezuñas o ganas de fiesta. Cada
             miembro trae su propia locura.
           </p>
-          <div class="team-grid">
+          <button
+            type="button"
+            class="team-toggle"
+            aria-expanded="false"
+            aria-controls="team-grid"
+            data-collapsed-label="Ver la cuadrilla"
+            data-expanded-label="Ocultar la cuadrilla"
+          >
+            <span class="team-toggle__label">Ver la cuadrilla</span>
+            <span class="team-toggle__icon" aria-hidden="true"></span>
+          </button>
+          <div class="team-grid team-grid--collapsible is-collapsed" id="team-grid">
             <article class="team-card">
               <h3>Ana "La Capotera"</h3>
               <p>Directora creativa, inventora del capote reversible (fiesta por un lado, siesta por el otro).</p>

--- a/script.js
+++ b/script.js
@@ -3,6 +3,8 @@ const yearSpan = document.getElementById("current-year");
 const navToggle = document.querySelector(".nav-toggle");
 const primaryNav = document.getElementById("primary-nav");
 const contactForm = document.querySelector("#contacto form");
+const teamToggle = document.querySelector(".team-toggle");
+const teamGrid = document.getElementById("team-grid");
 
 document.addEventListener("contextmenu", (event) => {
   event.preventDefault();
@@ -68,6 +70,59 @@ if (navToggle && primaryNav) {
       navToggle.setAttribute("aria-expanded", "false");
       primaryNav.classList.remove("primary-nav--open");
       document.body.classList.remove("no-scroll");
+    }
+  });
+}
+
+if (teamToggle && teamGrid) {
+  const label = teamToggle.querySelector(".team-toggle__label");
+  const collapsedLabel = teamToggle.dataset.collapsedLabel || "Ver la cuadrilla";
+  const expandedLabel = teamToggle.dataset.expandedLabel || "Ocultar la cuadrilla";
+  const mobileQuery = window.matchMedia("(max-width: 768px)");
+  let isExpandedOnMobile = false;
+
+  const setMobileState = (expanded) => {
+    isExpandedOnMobile = expanded;
+    teamToggle.setAttribute("aria-expanded", String(expanded));
+    teamGrid.classList.toggle("is-collapsed", !expanded);
+    teamToggle.classList.toggle("team-toggle--collapsed", !expanded);
+
+    if (label) {
+      label.textContent = expanded ? expandedLabel : collapsedLabel;
+    }
+  };
+
+  const applyMobileState = () => {
+    teamToggle.hidden = false;
+    setMobileState(isExpandedOnMobile);
+  };
+
+  const applyDesktopState = () => {
+    teamToggle.hidden = true;
+    teamGrid.classList.remove("is-collapsed");
+    teamToggle.classList.remove("team-toggle--collapsed");
+    teamToggle.setAttribute("aria-expanded", "true");
+
+    if (label) {
+      label.textContent = expandedLabel;
+    }
+  };
+
+  teamToggle.addEventListener("click", () => {
+    setMobileState(!isExpandedOnMobile);
+  });
+
+  if (mobileQuery.matches) {
+    applyMobileState();
+  } else {
+    applyDesktopState();
+  }
+
+  mobileQuery.addEventListener("change", (event) => {
+    if (event.matches) {
+      applyMobileState();
+    } else {
+      applyDesktopState();
     }
   });
 }

--- a/styles.css
+++ b/styles.css
@@ -387,6 +387,58 @@ section {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
+.team-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  margin: 1rem auto 1.5rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}
+
+.team-toggle__icon {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 999px;
+  border: 2px solid currentColor;
+  position: relative;
+  transition: transform 0.2s ease;
+}
+
+.team-toggle__icon::before,
+.team-toggle__icon::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 8px;
+  height: 2px;
+  background: currentColor;
+  transform-origin: center;
+  transition: transform 0.2s ease;
+}
+
+.team-toggle__icon::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.team-toggle__icon::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.team-toggle--collapsed .team-toggle__icon {
+  transform: none;
+}
+
+.team-toggle--collapsed .team-toggle__icon::before {
+  transform: translate(-50%, -50%) rotate(0deg);
+}
+
+.team-toggle--collapsed .team-toggle__icon::after {
+  transform: translate(-50%, -50%) rotate(90deg);
+}
+
 .team-card {
   background: white;
   border-radius: 18px;
@@ -863,6 +915,26 @@ footer a {
   to {
     opacity: 1;
     transform: translateY(0);
+  }
+}
+
+@media (max-width: 768px) {
+  .team-grid--collapsible.is-collapsed {
+    display: none;
+  }
+
+  .team-grid--collapsible {
+    margin-top: 0.5rem;
+  }
+
+  .team-toggle {
+    display: inline-flex;
+  }
+}
+
+@media (min-width: 769px) {
+  .team-grid--collapsible.is-collapsed {
+    display: grid;
   }
 }
 


### PR DESCRIPTION
## Summary
- add an accessible toggle button so the La cuadrilla cards can collapse on mobile viewports
- style the toggle control and icon plus responsive rules for the collapsible grid
- update client script to manage the responsive open/closed state of the team grid

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d94f9c6108832f8d18fd74d0e85234