### PR TITLE
Add toggle controls for Diwo chatbot

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,8 +229,18 @@
       aria-label="Chatbot ficticio Diwo compartiendo mensajes"
     >
       <header class="diwo-chatbot__header">
-        <span class="diwo-chatbot__avatar" aria-hidden="true">💬</span>
-        <span class="diwo-chatbot__title">Diwo</span>
+        <div class="diwo-chatbot__identity">
+          <span class="diwo-chatbot__avatar" aria-hidden="true">💬</span>
+          <span class="diwo-chatbot__title">Diwo</span>
+        </div>
+        <button
+          type="button"
+          id="diwo-chat-close"
+          class="diwo-chatbot__close"
+          aria-label="Cerrar chat Diwo"
+        >
+          ×
+        </button>
       </header>
       <div
         class="diwo-chatbot__body"
@@ -257,6 +267,17 @@
         <button type="submit" class="diwo-chatbot__send">Enviar</button>
       </form>
     </section>
+
+    <button
+      type="button"
+      id="diwo-chat-open"
+      class="diwo-chatbot__launcher"
+      aria-controls="diwo-chatbot"
+      aria-expanded="true"
+      hidden
+    >
+      Habla con Diwo
+    </button>
 
     <script src="script.js"></script>
   </body>

--- a/script.js
+++ b/script.js
@@ -5,6 +5,13 @@ const primaryNav = document.getElementById("primary-nav");
 const contactForm = document.querySelector("#contacto form");
 const teamToggle = document.querySelector(".team-toggle");
 const teamGrid = document.getElementById("team-grid");
+const diwoChatbot = document.getElementById("diwo-chatbot");
+const diwoChatOpenButton = document.getElementById("diwo-chat-open");
+const diwoChatCloseButton = document.getElementById("diwo-chat-close");
+const diwoMessagesList = document.getElementById("diwo-messages");
+const diwoChatBody = document.querySelector("#diwo-chatbot .diwo-chatbot__body");
+const diwoChatForm = document.getElementById("diwo-chat-form");
+const diwoChatInput = document.getElementById("diwo-chat-input");
 
 document.addEventListener("contextmenu", (event) => {
   event.preventDefault();
@@ -127,10 +134,46 @@ if (teamToggle && teamGrid) {
   });
 }
 
-const diwoMessagesList = document.getElementById("diwo-messages");
-const diwoChatBody = document.querySelector("#diwo-chatbot .diwo-chatbot__body");
-const diwoChatForm = document.getElementById("diwo-chat-form");
-const diwoChatInput = document.getElementById("diwo-chat-input");
+if (diwoChatbot && diwoChatOpenButton) {
+  const setDiwoChatVisibility = (shouldOpen) => {
+    const wasOpen = !diwoChatbot.hidden;
+
+    diwoChatbot.hidden = !shouldOpen;
+    diwoChatbot.setAttribute("aria-hidden", shouldOpen ? "false" : "true");
+
+    diwoChatOpenButton.hidden = shouldOpen;
+    diwoChatOpenButton.setAttribute("aria-expanded", shouldOpen ? "true" : "false");
+
+    if (diwoChatCloseButton) {
+      diwoChatCloseButton.setAttribute("aria-expanded", shouldOpen ? "true" : "false");
+    }
+
+    if (shouldOpen && !wasOpen && diwoChatInput) {
+      diwoChatInput.focus();
+    }
+  };
+
+  const prefersCollapsed = window.matchMedia("(max-width: 768px)").matches;
+  setDiwoChatVisibility(!prefersCollapsed);
+
+  diwoChatOpenButton.addEventListener("click", () => {
+    setDiwoChatVisibility(true);
+  });
+
+  if (diwoChatCloseButton) {
+    diwoChatCloseButton.addEventListener("click", () => {
+      setDiwoChatVisibility(false);
+      diwoChatOpenButton.focus();
+    });
+  }
+
+  window.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && !diwoChatbot.hidden) {
+      setDiwoChatVisibility(false);
+      diwoChatOpenButton.focus();
+    }
+  });
+}
 
 const appendDiwoMessage = (text, author = "bot") => {
   if (!diwoMessagesList) {

--- a/styles.css
+++ b/styles.css
@@ -769,13 +769,22 @@ footer a {
 .diwo-chatbot__header {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
+  justify-content: space-between;
+  gap: 0.75rem;
   padding: 0.75rem 1rem;
   background: linear-gradient(135deg, rgba(179, 0, 27, 0.9), rgba(245, 197, 66, 0.85));
   color: white;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 1px;
+}
+
+.diwo-chatbot__identity {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 1;
+  min-width: 0;
 }
 
 .diwo-chatbot__avatar {
@@ -786,6 +795,34 @@ footer a {
   border-radius: 50%;
   background: rgba(255, 255, 255, 0.18);
   font-size: 1.1rem;
+}
+
+.diwo-chatbot__close {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  background: rgba(0, 0, 0, 0.2);
+  color: white;
+  font-size: 1.3rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.diwo-chatbot__close:hover,
+.diwo-chatbot__close:focus {
+  background: rgba(0, 0, 0, 0.35);
+  transform: rotate(90deg);
+}
+
+.diwo-chatbot__close:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
 }
 
 .diwo-chatbot__body {
@@ -880,6 +917,38 @@ footer a {
 .diwo-chatbot__send:active {
   transform: translateY(0);
   box-shadow: none;
+}
+
+.diwo-chatbot__launcher {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  font-size: 1rem;
+  font-weight: 700;
+  background: linear-gradient(135deg, rgba(179, 0, 27, 0.95), rgba(245, 197, 66, 0.9));
+  color: white;
+  box-shadow: 0 18px 45px rgba(26, 26, 26, 0.2);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  z-index: 999;
+}
+
+.diwo-chatbot__launcher:hover,
+.diwo-chatbot__launcher:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 50px rgba(179, 0, 27, 0.3);
+}
+
+.diwo-chatbot__launcher:focus {
+  outline: 3px solid rgba(179, 0, 27, 0.35);
+  outline-offset: 3px;
 }
 
 .sr-only {
@@ -1059,6 +1128,13 @@ footer a {
     border-radius: 22px;
   }
 
+  .diwo-chatbot__launcher {
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    width: auto;
+  }
+
   footer {
     padding: 2rem 1.25rem;
   }
@@ -1084,9 +1160,19 @@ footer a {
     border-radius: 20px;
   }
 
+  .diwo-chatbot__launcher {
+    left: 0.5rem;
+    right: 0.5rem;
+    bottom: 0.5rem;
+  }
+
   .diwo-chatbot__header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .diwo-chatbot__identity {
     justify-content: center;
     text-align: center;
-    gap: 0.75rem;
   }
 }


### PR DESCRIPTION
## Summary
- add a header close button and floating launcher to control the Diwo chatbot
- update chatbot styles for the new controls across desktop and mobile breakpoints
- implement JavaScript to toggle visibility with focus management and keyboard support

## Testing
- manual QA in browser

------
https://chatgpt.com/codex/tasks/task_e_68d95325cd1c832fb75b392ddf1ecb8a