### PR TITLE
Improve Diwo chatbot close control on mobile

### DIFF
--- a/script.js
+++ b/script.js
@@ -160,10 +160,60 @@ if (diwoChatbot && diwoChatOpenButton) {
     setDiwoChatVisibility(true);
   });
 
-  if (diwoChatCloseButton) {
-    diwoChatCloseButton.addEventListener("click", () => {
-      setDiwoChatVisibility(false);
+  const focusLauncher = () => {
+    if (typeof diwoChatOpenButton.focus !== "function") {
+      return;
+    }
+
+    try {
+      diwoChatOpenButton.focus({ preventScroll: true });
+    } catch (error) {
       diwoChatOpenButton.focus();
+    }
+  };
+
+  if (diwoChatCloseButton) {
+    let lastCloseTimestamp = 0;
+
+    const closeChat = (event) => {
+      if (event) {
+        event.preventDefault();
+        const now = Date.now();
+        if (event.type === "click" && now - lastCloseTimestamp < 350) {
+          return;
+        }
+        lastCloseTimestamp = now;
+      }
+
+      setDiwoChatVisibility(false);
+      focusLauncher();
+    };
+
+    diwoChatCloseButton.addEventListener("click", closeChat);
+
+    if (window.PointerEvent) {
+      diwoChatCloseButton.addEventListener(
+        "pointerup",
+        (event) => {
+          if (event.pointerType === "touch") {
+            closeChat(event);
+          }
+        },
+        { passive: false }
+      );
+    } else {
+      diwoChatCloseButton.addEventListener(
+        "touchend",
+        closeChat,
+        { passive: false }
+      );
+    }
+
+    diwoChatCloseButton.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        closeChat();
+      }
     });
   }
 

--- a/styles.css
+++ b/styles.css
@@ -800,8 +800,8 @@ footer a {
 .diwo-chatbot__close {
   display: grid;
   place-items: center;
-  width: 32px;
-  height: 32px;
+  width: 44px;
+  height: 44px;
   border-radius: 50%;
   border: 1px solid rgba(255, 255, 255, 0.4);
   background: rgba(0, 0, 0, 0.2);
@@ -812,6 +812,7 @@ footer a {
   transition: transform 0.2s ease, background 0.2s ease;
   margin-left: auto;
   flex-shrink: 0;
+  touch-action: manipulation;
 }
 
 .diwo-chatbot__close:hover,


### PR DESCRIPTION
## Summary
- expand the Diwo chatbot close button touch target so that it is easier to tap on phones
- add defensive focus handling when closing the chatbot to avoid layout jumps
- handle touch and pointer events explicitly so the close action always fires on mobile devices without double-triggering

## Testing
- `python3 -m http.server 8000` (manual)
- `playwright tap close button (iPhone 12)`


------
https://chatgpt.com/codex/tasks/task_e_68d955238d6c832f80790a1d220cba99