### PR TITLE
Revert repository to commit 2ee3928ea421e24e678e545bd7f83d98633239f9

### DIFF
--- a/update_gallery.py
+++ b/update_gallery.py
@@ -12,28 +12,16 @@ ATTACHMENTS_DIR = Path("/tmp/user_uploaded_attachments")
 
 DESCRIPTIONS = [
     {
-        "alt": "Rome desayunando en una terraza mientras sostiene una paloma.",
-        "caption": "Rome negocia con la paloma barista para conseguir café infinito y wifi en la terraza.",
+        "alt": "Hombre desayunando mientras sostiene una paloma sobre la taza de café.",
+        "caption": "Reunión creativa con la nueva consultora alada del departamento de marketing.",
     },
     {
-        "alt": "Rome preparando un avión de papel desde la ventana de una oficina moderna.",
-        "caption": "Rome lanza el informe trimestral en avión de papel para ahorrar en presentaciones de PowerPoint.",
+        "alt": "Empleado lanzando un avión de papel desde una ventana de oficina.",
+        "caption": "Presentación trimestral resumida en avión: KPIs volando directo al cliente.",
     },
     {
-        "alt": "Rome recostado dentro de un ataúd durante un ensayo teatral.",
-        "caption": "Rome prueba la siesta eterna premium antes de firmar el contrato con la funeraria boutique.",
-    },
-    {
-        "alt": "Rome dormido en el asiento trasero de un coche con el cinturón abrochado.",
-        "caption": "Rome activa el modo avión humano y se queda dormido antes de que el GPS diga recalculando.",
-    },
-    {
-        "alt": "Rome en silla de ruedas con la pierna escayolada acompañado a la salida de un hospital.",
-        "caption": "Rome presume de escayola con purpurina tras intentar torear una impresora 3D industrial.",
-    },
-    {
-        "alt": "Rome vestido de torero posando en la plaza junto a una amiga.",
-        "caption": "Rome luce traje de luces justo antes de torear la reunión anual de recursos humanos.",
+        "alt": "Persona recostada dentro de un ataúd durante un ensayo.",
+        "caption": "Simulacro de siesta eterna para evaluar la comodidad del ataúd VIP con climatizador.",
     },
 ]
 


### PR DESCRIPTION
## Summary
- restore the public site markup to the exact contents from commit 2ee3928ea421e24e678e545bd7f83d98633239f9
- revert the gallery update script to the descriptions bundled in that commit

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd6d9b3dd4832f873e12214699405c