### PR TITLE
Replace gallery PNGs with SVG placeholders

### DIFF
--- a/static/img/gallery/rome_avion_papel.svg
+++ b/static/img/gallery/rome_avion_papel.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#9ad0ff"/>
+      <stop offset="100%" stop-color="#ffffff"/>
+    </linearGradient>
+  </defs>
+  <rect width="600" height="400" fill="url(#sky)"/>
+  <path d="M120 230 L300 140 L480 230 L360 210 L300 260 L240 210 Z" fill="#f7f7f7" stroke="#3a6ea5" stroke-width="6" stroke-linejoin="round"/>
+  <circle cx="300" cy="260" r="12" fill="#3a6ea5"/>
+  <text x="300" y="340" font-family="'Montserrat', Arial, sans-serif" font-size="42" text-anchor="middle" fill="#27496d">Rome lanza su avión de papel</text>
+</svg>

--- a/static/img/gallery/rome_cafe_paloma.svg
+++ b/static/img/gallery/rome_cafe_paloma.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#fbe9e7"/>
+  <path d="M180 220 C210 160 270 140 300 200 C330 140 390 160 420 220 C420 320 300 340 300 340 C300 340 180 320 180 220 Z" fill="#ffffff" stroke="#d2691e" stroke-width="6"/>
+  <path d="M260 260 C260 240 280 220 300 220 C320 220 340 240 340 260" fill="#f5deb3"/>
+  <rect x="260" y="260" width="80" height="70" rx="12" fill="#6d4c41"/>
+  <text x="300" y="120" font-family="'Montserrat', Arial, sans-serif" font-size="40" text-anchor="middle" fill="#6d4c41">Rome comparte café con Paloma</text>
+</svg>

--- a/static/img/gallery/rome_ensayo_ataud.svg
+++ b/static/img/gallery/rome_ensayo_ataud.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#1f1f1f"/>
+  <rect x="120" y="80" width="360" height="240" rx="40" fill="#3c2f2f" stroke="#9e7c4f" stroke-width="8"/>
+  <rect x="160" y="120" width="280" height="160" rx="28" fill="#5c4536"/>
+  <circle cx="300" cy="200" r="48" fill="#f4d35e"/>
+  <path d="M260 210 L300 170 L340 210" fill="none" stroke="#1f1f1f" stroke-width="8" stroke-linecap="round"/>
+  <text x="300" y="340" font-family="'Montserrat', Arial, sans-serif" font-size="40" text-anchor="middle" fill="#f4d35e">Rome ensaya su salida del ataúd</text>
+</svg>

--- a/static/img/gallery/rome_saluda_hospital.svg
+++ b/static/img/gallery/rome_saluda_hospital.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#e8f5e9"/>
+  <rect x="60" y="60" width="480" height="220" fill="#ffffff" stroke="#66bb6a" stroke-width="8" rx="24"/>
+  <rect x="140" y="120" width="80" height="80" fill="#bbdefb" rx="12"/>
+  <rect x="380" y="120" width="80" height="80" fill="#bbdefb" rx="12"/>
+  <path d="M240 280 Q300 220 360 280" fill="none" stroke="#66bb6a" stroke-width="12" stroke-linecap="round"/>
+  <text x="300" y="340" font-family="'Montserrat', Arial, sans-serif" font-size="40" text-anchor="middle" fill="#388e3c">Rome saluda a los médicos del hospital</text>
+</svg>

--- a/static/img/gallery/rome_siesta_coche.svg
+++ b/static/img/gallery/rome_siesta_coche.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#fff9c4"/>
+  <rect x="120" y="200" width="360" height="120" rx="40" fill="#90caf9" stroke="#0d47a1" stroke-width="10"/>
+  <circle cx="200" cy="340" r="32" fill="#0d47a1"/>
+  <circle cx="400" cy="340" r="32" fill="#0d47a1"/>
+  <path d="M240 200 Q300 120 360 200" fill="#0d47a1"/>
+  <text x="300" y="140" font-family="'Montserrat', Arial, sans-serif" font-size="40" text-anchor="middle" fill="#f57f17">Rome duerme la siesta en su coche</text>
+</svg>

--- a/static/img/gallery/rome_traje_luces.svg
+++ b/static/img/gallery/rome_traje_luces.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <rect width="600" height="400" fill="#ede7f6"/>
+  <path d="M300 80 C260 100 240 160 260 220 L220 320 L260 320 L300 260 L340 320 L380 320 L340 220 C360 160 340 100 300 80" fill="#9575cd" stroke="#4527a0" stroke-width="10" stroke-linejoin="round"/>
+  <circle cx="300" cy="120" r="40" fill="#d1c4e9" stroke="#4527a0" stroke-width="8"/>
+  <path d="M260 200 H340" stroke="#ffca28" stroke-width="12" stroke-linecap="round"/>
+  <text x="300" y="360" font-family="'Montserrat', Arial, sans-serif" font-size="40" text-anchor="middle" fill="#4527a0">Rome luce su traje de luces</text>
+</svg>

--- a/styles.css
+++ b/styles.css
@@ -365,7 +365,7 @@ section {
   transition: transform 0.3s ease;
 }
 
-.gallery-item span {
+.gallery-item figcaption {
   position: absolute;
   bottom: 0;
   left: 0;


### PR DESCRIPTION
## Summary
- replace the binary PNG gallery assets with lightweight SVG illustrations so the repository stays text-only
- update the gallery markup to load the new SVG files while preserving the existing captions and layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de566e1da4832f9752cef7a6e9c089