### PR TITLE
Actualizar descripciones de la galería según las fotos

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,27 +126,27 @@
           <div class="gallery-grid">
             <figure class="gallery-item">
               <img src="static/images/gallery/image_1.jpeg" alt="">
-              <span>Reunión creativa con la nueva consultora alada del departamento de marketing.</span>
+              <span>Rome abandona la enfermería en silla de ruedas, presumiendo el yeso que ganó domando la escalera.</span>
             </figure>
             <figure class="gallery-item">
               <img src="static/images/gallery/image_2.jpeg" alt="">
-              <span>Presentación trimestral resumida en avión: KPIs volando directo al cliente.</span>
+              <span>Rome negocia la táctica del pase de pecho con su consultora paloma durante el desayuno.</span>
             </figure>
             <figure class="gallery-item">
               <img src="static/images/gallery/image_3.jpeg" alt="">
-              <span>Simulacro de siesta eterna para evaluar la comodidad del ataúd VIP con climatizador.</span>
+              <span>Rome lanza el avión de papel con la estrategia de faena rumbo a la plaza rival.</span>
             </figure>
             <figure class="gallery-item">
               <img src="static/images/gallery/image_4.jpeg" alt="">
-              <span>Simulacro de siesta eterna para evaluar la comodidad del ataúd VIP con climatizador.</span>
+              <span>Rome aprovecha el taxi oficial para echar la siesta táctica camino del paseíllo.</span>
             </figure>
             <figure class="gallery-item">
               <img src="static/images/gallery/image_5.jpeg" alt="">
-              <span>Simulacro de siesta eterna para evaluar la comodidad del ataúd VIP con climatizador.</span>
+              <span>Rome ensaya la despedida triunfal probando el ataúd con vista privilegiada a los ramos.</span>
             </figure>
             <figure class="gallery-item">
               <img src="static/images/gallery/image_6.jpeg" alt="">
-              <span>Simulacro de siesta eterna para evaluar la comodidad del ataúd VIP con climatizador.</span>
+              <span>Rome posa de luces en el albero con su jefa de prensa antes de abrir la puerta grande.</span>
             </figure>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- ajustar los textos de la galería de faenas memorables para que describan con precisión cada fotografía

## Testing
- no se realizaron pruebas; cambios solo en contenido estático

------
https://chatgpt.com/codex/tasks/task_e_68de5de9a7f0832fb0e4d41e224a3c9a