### PR TITLE
Document Tesaco el Toro website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-Hello world!
+# Tesaco el Toro
+
+## Introduction
+Tesaco el Toro is a tongue-in-cheek landing page that showcases an imaginary squad of bull-wrangling specialists. The site combines playful copywriting with bold visuals to tell the story of Rome and the crew who rescue runaway bulls, stage absurd capeas, and throw over-the-top celebrations.
+
+## About the Project
+The website presents the brand's services, a gallery of "faenas memorables," team highlights, contact information, and an interactive taurine quiz. Every section leans into the comedic personality of Tesaco el Toro, embracing Spanish-language humor and a fiesta-inspired aesthetic to entertain visitors while explaining the group's extravagant offerings.
+
+## Live Site
+The site is deployed at [https://jchierro.github.io/tesacoeltoro/](https://jchierro.github.io/tesacoeltoro/).
+
+## Getting Started
+This is a static website. To explore or adapt it locally:
+
+1. Clone the repository.
+   ```bash
+   git clone https://github.com/jchierro/tesacoeltoro.git
+   ```
+2. Open the project folder and launch the site in your browser by opening `index.html`.
+   ```bash
+   cd tesacoeltoro
+   open index.html # use xdg-open or start on Windows
+   ```
+3. Update the HTML, CSS, or assets under `static/` and refresh your browser to preview changes.
+
+## Contributing
+Contributions that improve content, accessibility, or the overall experience are welcome:
+
+- Fork the repository and create a feature branch.
+- Make your updates and ensure the site still renders correctly.
+- Submit a pull request describing the changes and motivation.
+
+Please keep the playful spirit of Tesaco el Toro in mind when proposing edits.
+
+## License
+TBD.


### PR DESCRIPTION
## Summary
- replace the placeholder README with an overview of the Tesaco el Toro website and its purpose
- document how to access the live deployment, explore the project locally, and contribute updates

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68deb5a52708832f8b95dde818b5d1fa