### PR TITLE
Add group photo to La cuadrilla section

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,6 +158,13 @@
             Somos un equipo de especialistas en todo lo que tenga cuernos, pezuñas o ganas de fiesta. Cada
             miembro trae su propia locura.
           </p>
+          <div class="crew-photo">
+            <img
+              src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80"
+              alt="Integrantes de la cuadrilla sonriendo durante la despedida"
+              class="crew-photo-img"
+            />
+          </div>
         </div>
       </section>
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -311,6 +311,19 @@ section {
   margin-bottom: 2rem;
 }
 
+.crew-photo {
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.crew-photo-img {
+  max-width: 600px;
+  width: 100%;
+  border-radius: 16px;
+  box-shadow: 0 18px 36px rgba(26, 26, 26, 0.18);
+}
+
 .card-grid {
   display: grid;
   gap: 1.5rem;


### PR DESCRIPTION
## Summary
- add a representative group photo to the "La cuadrilla" section using an external CDN image
- center and constrain the new crew image with dedicated styles

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68deb6d190d8832fb6cfe49939cb3c22